### PR TITLE
fix: handle multi-valued fields and process all copy_tags

### DIFF
--- a/beetsplug/tagcopy.py
+++ b/beetsplug/tagcopy.py
@@ -78,11 +78,11 @@ class TagCopy(BeetsPlugin):
 
   def process_item(self, item):
     for copy_to, copy_from in self.get_copy_tag_defs():
+      value = item[copy_from]
+      if isinstance(value, list):
+        value = '; '.join(value)
 
-      if self.is_only_empty_tags_enabled:
-        if not item[copy_to]:
-          item[copy_to] = item[copy_from]
-      else:
-        item[copy_to] = item[copy_from]
+      if not self.is_only_empty_tags_enabled or not item[copy_to]:
+        item[copy_to] = value
 
-      return item
+    return item


### PR DESCRIPTION
When copying multi-valued fields like `artists` (stored as list internally), the plugin was copying the raw list object instead of joining it into a string. This caused fields like `artist` to be set to `['Artist1', 'Artist2']` instead of `'Artist1; Artist2'`.

Additionally, the return statement was inside the loop, causing only the first copy_tags definition to be processed.

This change fixes both issues by joining list values with '; ' separator and moving the return statement outside the loop so all copy definitions are processed.
